### PR TITLE
Fix Persistent AA effects not working in the wake of their hack removal

### DIFF
--- a/src/game/Spells/Spell.cpp
+++ b/src/game/Spells/Spell.cpp
@@ -650,12 +650,6 @@ void Spell::FillTargetMap()
                         case TARGET_ALL_FRIENDLY_UNITS_IN_AREA:
                         case TARGET_AREAEFFECT_GO_AROUND_DEST:
                         case TARGET_RANDOM_NEARBY_DEST:
-                            // triggered spells get dest point from default target set, ignore it
-                            if (!(m_targets.m_targetMask & TARGET_FLAG_DEST_LOCATION) || m_IsTriggeredSpell)
-                                if (WorldObject* castObject = GetCastingObject())
-                                    m_targets.setDestination(castObject->GetPositionX(), castObject->GetPositionY(), castObject->GetPositionZ());
-                            SetTargetMap(SpellEffectIndex(i), m_spellInfo->EffectImplicitTargetB[i], tmpUnitLists[i /*==effToIndex[i]*/]);
-                            break;
                         // target pre-selection required
                         case TARGET_INNKEEPER_COORDINATES:
                         case TARGET_TABLE_X_Y_Z_COORDINATES:
@@ -2182,7 +2176,9 @@ void Spell::SetTargetMap(SpellEffectIndex effIndex, uint32 targetMode, UnitList&
             // targets the ground, not the units in the area
             switch (m_spellInfo->Effect[effIndex])
             {
-                case SPELL_EFFECT_PERSISTENT_AREA_AURA:
+                case SPELL_EFFECT_PERSISTENT_AREA_AURA: // should be dest only target
+                    if (m_spellInfo->Targets & TARGET_FLAG_DEST_LOCATION)
+                        targetUnitMap.push_back(m_caster);
                     break;
                 case SPELL_EFFECT_SUMMON:
                     targetUnitMap.push_back(m_caster);
@@ -2408,6 +2404,13 @@ void Spell::SetTargetMap(SpellEffectIndex effIndex, uint32 targetMode, UnitList&
             // targets the ground, not the units in the area
             if (m_spellInfo->Effect[effIndex] != SPELL_EFFECT_PERSISTENT_AREA_AURA)
                 FillAreaTargets(targetUnitMap, radius, PUSH_DEST_CENTER, SPELL_TARGETS_AOE_ATTACKABLE);
+            else
+            {
+                if (Unit* target = m_targets.getUnitTarget()) // trap activation where we supply triggerer
+                    targetUnitMap.push_back(target);
+                else
+                    targetUnitMap.push_back(m_caster); // cases like blizzard
+            }
             break;
         case TARGET_MINION:
             if (m_spellInfo->Effect[effIndex] != SPELL_EFFECT_DUEL)


### PR DESCRIPTION
These "hacks" make sure we fill at least one unit target. The course of
action is to make dest-only effects execute without targets.

Closes https://github.com/cmangos/issues/issues/1560